### PR TITLE
make library-path configurable for server-only installs

### DIFF
--- a/application.py
+++ b/application.py
@@ -12,7 +12,10 @@ def main_page():
 
 @application.route('/<int:id>/')
 def show_book_info(id):
-    book = Book(id)
+    library_path = None
+    if application.config.has_key('LIBRARY_PATH'):
+        library_path = application.config['LIBRARY_PATH']
+    book = Book(library_path, id)
     return render_book_info(book)
 
 

--- a/book.py
+++ b/book.py
@@ -4,12 +4,13 @@ __author__ = 'gyp'
 
 
 class Book:
-    def __init__(self, id):
+    def __init__(self, library_path, id):
         self.id = id
+        self.library_path = library_path
         self._load_attributes_from_calibre()
 
     def _load_attributes_from_calibre(self):
-        book_in_calibre_db = Calibre.get_book_data(self.id)
+        book_in_calibre_db = Calibre.get_book_data(self.library_path, self.id)
         if book_in_calibre_db is None:
             current_app.logger.warning('Requested book page with unknown ID, id=%s', self.id)
             abort(404)

--- a/calibre.py
+++ b/calibre.py
@@ -5,12 +5,14 @@ __author__ = 'gyp'
 
 class Calibre:
     @staticmethod
-    def get_book_data(book_id):
+    def get_book_data(library_path, book_id):
         book_id = int(book_id)
-        json_results = Calibre._call_calibredb("list",
-                                              "--for-machine",
-                                              "-s", "id:%d" % book_id,
-                                              "-f", "all")
+	dbargs = ["list", "--for-machine",
+                  "-s", "id:%d" % book_id,
+                  "-f", "all" ]
+        if library_path:
+            dbargs +=  ["--with-library", "%s" % library_path]
+        json_results = Calibre._call_calibredb(dbargs)
         results = json.loads(json_results)
         if len(results) == 0:
             return None
@@ -18,8 +20,8 @@ class Calibre:
         return results[0]
 
     @staticmethod
-    def _call_calibredb(*args):
-        return subprocess.check_output(["calibredb"] + list(args)).decode()
+    def _call_calibredb(parameters):
+        return subprocess.check_output(["calibredb"] + list(parameters)).decode()
 
     @staticmethod
     def set_custom(book_id, field_name, field_value):

--- a/configuration.py.sample
+++ b/configuration.py.sample
@@ -1,3 +1,4 @@
 DEBUG = True
 SHELVES = ['attic', 'basement', 'living room']
 CALIBRE_URL = "http://localhost:8080/"
+LIBRARY_PATH = "/home/calibre/calibre-library"


### PR DESCRIPTION
with clean calibre-server installs, you don't need to start a GUI or manually the library path in an oscure location (e.g. ~/.config/calibre/global.py), but specify it in the tracker config file
